### PR TITLE
Remove `failure`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: rust
 rust:
-  - nightly
+  - stable
 
 before_script: |
-  rustup component add rustfmt-preview &&
-  rustup component add clippy-preview
+  rustup component add rustfmt &&
+  rustup component add clippy
 script: |
   cargo fmt -- --check &&
   cargo clippy -- -D clippy::all &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ documentation = "https://docs.rs/speedometer"
 description = "Measure throughput per second."
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
-failure = "0.1.2"
+instant = "0.1.2"
+
+[features]
+stdweb = ["instant/stdweb"]
+wasm-bindgen = ["instant/wasm-bindgen"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Or anything similar. This module allows you to do so in synchronous code.
 
 ## Usage
 ```rust
-extern crate speedometer;
 use speedometer::Speedometer;
 use std::time::Duration;
 
@@ -23,10 +22,11 @@ let window_size = Duration::from_secs(5); // default is 5 second window size
 let mut meter = Speedometer::new(window_size);
 meter.entry(10);
 
-println!("{:?} bytes/second!", meter.measure().unwrap());
+println!("{:?} bytes/second!", meter.measure());
 ```
 
 ## Installation
+With [cargo-edit](https://github.com/killercup/cargo-edit) do:
 ```sh
 $ cargo add speedometer
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,19 @@
 #![forbid(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 
+//! Measure throughput per second. Adapted from
+//! [mafintosh/speedometer](https://github.com/mafintosh/speedometer).
+//!
+//! ## Why?
+//! It's often useful to figure out the average over a sliding timeframe. For
+//! example: "how many bytes did we receive on average over the last 5
+//! seconds?". Or anything similar. This module allows you to do so in
+//! synchronous code.
+//!
+//! ## WebAssembly
+//! When targeting WebAssembly, enable either the `stdweb` feature or the
+//! `wasm-bindgen` feature, depending on what you use.
+//!
 //! ## Examples
 //! ```rust
 //! extern crate speedometer;
@@ -14,19 +27,17 @@
 //! let mut meter = Speedometer::new(window_size);
 //! meter.entry(10);
 //!
-//! println!("{:?} bytes/second!", meter.measure().unwrap());
+//! println!("{:?} bytes/second!", meter.measure());
 //! ```
 //!
-extern crate failure;
-
-use failure::Error;
 use std::collections::vec_deque::VecDeque;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
+use instant::Instant;
 
 /// Entries into the queue.
 #[derive(Debug)]
 pub struct Entry {
-  timestamp: SystemTime,
+  timestamp: Instant,
   value: usize,
 }
 
@@ -73,16 +84,16 @@ impl Speedometer {
   pub fn entry(&mut self, value: usize) {
     self.total_value += value;
     self.queue.push_back(Entry {
-      timestamp: SystemTime::now(),
+      timestamp: Instant::now(),
       value,
     });
   }
 
   /// Measure the speed.
-  pub fn measure(&mut self) -> Result<usize, Error> {
+  pub fn measure(&mut self) -> usize {
     let mut max = 0;
     for (index, entry) in self.queue.iter_mut().enumerate() {
-      if entry.timestamp.elapsed()? > self.window_size {
+      if entry.timestamp.elapsed() > self.window_size {
         self.total_value -= entry.value;
       } else {
         max = index;
@@ -94,7 +105,7 @@ impl Speedometer {
       self.queue.pop_front();
     }
 
-    Ok(self.total_value / self.queue.len())
+    self.total_value / self.queue.len()
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,11 @@ impl Speedometer {
       self.queue.pop_front();
     }
 
-    self.total_value / self.queue.len()
+    if self.queue.is_empty() {
+      0
+    } else {
+      self.total_value / self.queue.len()
+    }
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,9 @@
 //! println!("{:?} bytes/second!", meter.measure());
 //! ```
 //!
+use instant::Instant;
 use std::collections::vec_deque::VecDeque;
 use std::time::Duration;
-use instant::Instant;
 
 /// Entries into the queue.
 #[derive(Debug)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,3 +18,10 @@ fn measures_entries() {
   sleep(window_size);
   assert_eq!(meter.measure(), 0);
 }
+
+#[test]
+fn no_entries() {
+  let window_size = Duration::from_secs(1);
+  let mut meter = Speedometer::new(window_size);
+  assert_eq!(meter.measure(), 0, "should not crash on empty queue");
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,10 +11,7 @@ fn measures_entries() {
   meter.entry(10);
   meter.entry(10);
   meter.entry(10);
-  assert!(
-    meter.measure() > 0,
-    "bytes per second should be non-zero"
-  );
+  assert!(meter.measure() > 0, "bytes per second should be non-zero");
   sleep(window_size);
   assert_eq!(meter.measure(), 0);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -12,9 +12,9 @@ fn measures_entries() {
   meter.entry(10);
   meter.entry(10);
   assert!(
-    meter.measure().unwrap() > 0,
+    meter.measure() > 0,
     "bytes per second should be non-zero"
   );
   sleep(window_size);
-  assert_eq!(meter.measure().unwrap(), 0);
+  assert_eq!(meter.measure(), 0);
 }


### PR DESCRIPTION
`failure` doesn't compile for me? it's also a bit much for a single
possible error type :)

- Update to 2018 Edition.
- Support WASM using the `instant` crate.
- `Instant` does not return an error, so `failure` can be removed.